### PR TITLE
Improve caching in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
 FROM node:19-alpine
 
+# Make the app directory
 WORKDIR /website_fosscu
 
-COPY . /website_fosscu/
+# Copy built sources from project
+COPY ./package.json .
+COPY ./yarn.lock .
+COPY ./package-lock.json .
 
-RUN yarn add vite
-
+# Installing all dependencies
 RUN yarn install
 
+# Copy all files into container
+COPY . .
+
+# Run the production build
+RUN yarn build
+
+# Start the server
 CMD ["yarn", "start"]


### PR DESCRIPTION
The problem with the previous docker image was that when the docker build command was run after any changes on the coding, it ran from the `RUN yarn add vite` step and took too long to build the docker image.

We don't need to run `RUN yarn add vite`. I skip this and Now it is taking a shorter time to build the docker image.

Review my pull request and let me know if there's anything else I need to do.