### PR TITLE
added "What is FOSS" page in footer under handbook column

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -63,6 +63,9 @@ const Footer = () => {
             <a href="https://docs.fosscu.org/Docs/code-of-conduct" className="pb-2">
               <li className="pt-2 w-max text-sum hover:border-b hover:border-green-400">Code of Conduct</li>
             </a>
+            <a href="https://docs.fosscu.org/Docs/getting-started" className="pb-2">
+              <li className="pt-2 w-max text-sum hover:border-b hover:border-green-400">What is FOSS</li>
+            </a>
             <a href="/building" className="pb-2">
               <li className="pt-2 w-max text-sum hover:border-b hover:border-green-400">Terms</li>
             </a>


### PR DESCRIPTION
I added the "what is FOSS" page which is located in "FOSSCU handbook" in the footer section under handbook column. This will help visitors to know about what is FOSS and what does it aim at.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
