### PR TITLE
Fixed canlender and contribute tabs not showing in mobile view.

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -113,6 +113,13 @@ const Navbar = () => {
             <li className="p-4 border-b border-gray-600">
               <Link to="/contact">Contact</Link>
             </li>
+            <li className="p-4 border-b border-gray-600">
+              <Link to="https://lu.ma/fosscu">Calender</Link>
+            </li>
+            <li className="p-4 border-b border-gray-600">
+              <Link to="https://github.com/FOSS-Community/">Contribute</Link>
+            </li>
+            
           </ul>
         </div>
       </div >


### PR DESCRIPTION
# Description

I added the missing calender and contribute tabs in menu in mobile view. 

Fixes #192 
## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
 I tested it by running it on my mobile.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes