### PR TITLE
[feat]: Add Conventional Commits Checker Action to Repository

### DIFF
--- a/.github/workflows/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/.github/workflows/conventional-commits.yml
@@ -1,0 +1,13 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: webiny/action-conventional-commits@v1.1.0


### PR DESCRIPTION
[feat]: Add Conventional Commits Checker Action to Repository

This PR introduces a new feature to the repository by adding the "Conventional Commits Checker Action." This action automates the process of checking commits against conventional commit message standards, enhancing the project's commit consistency and making it easier to manage version releases.

Key Changes:
- Added a GitHub Actions workflow for Conventional Commits checking.
- Configured the action to run on every push to the repository.
- Updated the README with instructions on how to use the new action.

This contribution aligns with our commitment to improving the development process and maintaining a clean and well-documented commit history.

Closes #211
